### PR TITLE
chore(agentic): agent docs split

### DIFF
--- a/.github/agents/movefit-ci.agent.md
+++ b/.github/agents/movefit-ci.agent.md
@@ -22,6 +22,14 @@ user-invocable: false
 
 This agent creates and validates CI configurations.
 
+## Purpose
+
+- standard CI pipeline with `python -m pytest`, `hatchling check`, and package build.
+
+## Usage
+
+- As movefit-ci, add workflow definitions + minimal matrix for 3.11+.
+
 ## Focus
 
 - `.github/workflows/python-app.yml`

--- a/.github/agents/movefit-tests.agent.md
+++ b/.github/agents/movefit-tests.agent.md
@@ -18,6 +18,14 @@ user-invocable: false
 
 This agent writes tests and validates behavior with real cases.
 
+## Purpose
+
+- enforce test-first behavior and assertion patterns.
+
+## Usage
+
+- As movefit-tests, generate unit test stubs and run `pytest` after each PR.
+
 ## Focus
 
 - API tests using `TestClient` for endpoints

--- a/.github/instructions/movefit-python.instructions.md
+++ b/.github/instructions/movefit-python.instructions.md
@@ -1,0 +1,12 @@
+---
+name: movefit-python
+description: "Use when editing Python code in src/movefit; enforce package conventions, typing, and tests."
+applyTo: "src/movefit/**/*.py"
+---
+
+- Keep modules small and focused.
+- Use Python 3.11 idioms and type hints for public API.
+- Prefer explicit relative imports within movefit.
+- Add or update `tests/` when implementing behavior.
+- Use `python -m pytest` and aim for fast deterministic tests.
+- Avoid external dependencies unless needed; keep minimal.

--- a/.github/instructions/movefit-tests.instructions.md
+++ b/.github/instructions/movefit-tests.instructions.md
@@ -1,0 +1,11 @@
+---
+name: movefit-tests
+description: "Use when editing tests/ and adding new test coverage for movefit behavior."
+applyTo: "tests/**/*.py"
+---
+
+- Write tests for new behavior before implementation when possible.
+- Use pytest fixtures and parametrization, keep tests clear and independent.
+- Focus on core domain logic and edge cases, not implementation internals.
+- Run `python -m pytest --maxfail=1 -q` locally before PR.
+- Add a new `tests/test_*.py` file per new module in src/movefit.


### PR DESCRIPTION
- Added purpose/usage docs in movefit-ci and movefit-tests agents
- Added movefit-python and movefit-tests instructions in .github/instructions

Review items:
1. movefit-ci.agent.md
2. movefit-tests.agent.md
3. .github/instructions/*

Labels: agentic, docs